### PR TITLE
Allow usage with webpack 2.2 and with postcss-js up to 1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "scripts": {},
   "peerDependencies": {
     "postcss": "^5.0.14",
-    "postcss-js": "^0.1.1",
-    "webpack": "^1.12.9"
+    "postcss-js": ">=0.1.1 <1.0",
+    "webpack": "^1.12.9 || ^2.2.0"
   },
   "keywords": [
     "webpack",


### PR DESCRIPTION
Hey!

I'm using your loader with webpack 2 and postcss-js 0.3.0 and didn't notice any issues. So I'm suggesting to allow these versions as peer dependencies.